### PR TITLE
Updated mocha-jsdom to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,8 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
-    "jsdom": "^9.0.0",
     "mocha": "^2.4.5",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "^2.0.0",
     "mocha-multi": "^0.9.0"
   }
 }


### PR DESCRIPTION
Due to breaking change this package needs to be updated. Also jsdom package is now required via mocha-jsdom and no longer needs to be included in package.json.