### PR TITLE
new solution to go with new tests/readme that don't make incrementVariable() irrelevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,7 @@ Remember how we couldn't be sure with the plain `while` loop above that the body
 would run using `maybeTrue()`? With `do`, we _can_ be sure that the body will
 run!
 
-**TODO**: Define a function called `doWhileLoop` in `loops.js`. The function should take
-an array as an argument. Use the `incrementVariable()` function (you can copy it
-from this README) as the condition, and remove elements from the array until the
-array is empty or until `incrementVariable()` returns `false`. (Your condition
-might look something like `array.length > 0 && incrementVariable()`.) Finally,
-return the array.
+TODO: Define a function called doWhileLoop in loops.js. The function should take an integer as an argument. Use the incrementVariable() function (you can copy it from this README) in the condition, and console log "I run once regardless." while incrementVariable() returns a number less than the parameter received. (Your condition might look something like incrementVariable() < num.) Remember that it should also console log when receiving 0 as a parameter because the do-while runs before the condition is checked.
 
 ## Conclusion
 

--- a/loops.js
+++ b/loops.js
@@ -18,18 +18,15 @@ function whileLoop(n) {
 	return 'done';
 }
 
-function doWhileLoop(array) {
+function doWhileLoop(num) {
 	var i = 0;
 
 	function incrementVariable() {
 		i = i + 1;
+    return i;
 	}
 
-	do {
-		console.log('array.length = ' + array.length + ' and i = ' + i);
-		array = array.slice(1);
-		incrementVariable();
-	} while (array.length > 0 && i < 5);
-
-	return array;
+  do {
+    console.log("I run once regardless.");
+  } while (incrementVariable() < num);
 }

--- a/test/loops-test.js
+++ b/test/loops-test.js
@@ -53,14 +53,17 @@ describe('loops', () => {
 		});
 	});
 
-	describe('doWhileLoop(array)', () => {
-		it('removes elements from `array` until `array` is empty or until `maybeTrue()` returns `false`', () => {
-			const [array, t] = makeArray();
-			const l = array.length;
+  describe('doWhileLoop(num)', () => {
+    it ('console logs "I run once regardless." 1 time when passed an integer of 0 as a parameter.', () => {
+        const spy = chai.spy.on(console, 'log');
+        doWhileLoop(0);
+        expect(spy).to.have.been.called.exactly(1);
+    })
 
-			const newArray = doWhileLoop(array);
-
-			expect(newArray).to.have.length.of.at.most(l - 1);
-		});
+    it ('console logs "I run once regardless." 10 times when passed an integer of 10 as a parameter.', () => {
+      const spy = chai.spy.on(console, 'log');
+      doWhileLoop(10);
+      expect(spy).to.have.been.called.exactly(10);
+    })
 	});
 });


### PR DESCRIPTION
@sgharms 
tests could've been passed before with the following
```
function doWhileLoop(arr){
  do {
    arr.pop();
  } while (arr.length);
  return arr;
}
```