### PR TITLE
update readme and tests to not make doWhileLoop condition redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ function incrementVariable() {
 
 do {
   console.log("doo-bee-doo-bee-doo");
-  incrementVariable();
-} while (i < 5);
+} while (incrementVariable() < 5);
 ```
 
 Remember how we couldn't be sure with the plain `while` loop above that the body

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ var i = 0;
 
 function incrementVariable() {
   i = i + 1;
+  return i;
 }
 
 do {
@@ -202,11 +203,9 @@ would run using `maybeTrue()`? With `do`, we _can_ be sure that the body will
 run!
 
 **TODO**: Define a function called `doWhileLoop` in `loops.js`. The function should take
-an array as an argument. Use the `incrementVariable()` function (you can copy it
-from this README) as the condition, and remove elements from the array until the
-array is empty or until `incrementVariable()` returns `false`. (Your condition
-might look something like `array.length > 0 && incrementVariable()`.) Finally,
-return the array.
+an integer as an argument. Use the `incrementVariable()` function (you can copy it
+from this README) in the condition, and console log `"I run once regardless."` while `incrementVariable()` returns a number less than the parameter received. (Your condition
+might look something like `incrementVariable() < num`.) Remember that it should also console log when receiving 0 as a parameter because the do-while runs before the condition is checked.
 
 ## Conclusion
 

--- a/test/loops-test.js
+++ b/test/loops-test.js
@@ -34,7 +34,7 @@ describe('loops', () => {
 
       let first = "I am 1 strange loop."
       let rest = "I am 24 strange loops."
-        
+
       expect(strangeArray[11]).to.equal(first)
       expect(strangeArray[34]).to.equal(rest)
       expect(strangeArray.length).to.equal(t + 25)
@@ -53,14 +53,17 @@ describe('loops', () => {
     })
   })
 
-  describe('doWhileLoop(array)', () => {
-    it('removes elements from `array` until `array` is empty or until `incrementVariable()` returns `false`', () => {
-      const [array, t] = makeArray()
-      const l = array.length
+  describe('doWhileLoop(num)', () => {
+    it ('console logs "I run once regardless." 1 time when passed an integer of 0 as a parameter.', () => {
+        const spy = chai.spy.on(console, 'log');
+        doWhileLoop(0);
+        expect(spy).to.have.been.called.exactly(1);
+    })
 
-      const newArray = doWhileLoop(array)
-
-      expect(newArray).to.have.length.of.at.most(l - 1)
+    it ('console logs "I run once regardless." 10 times when passed an integer of 10 as a parameter.', () => {
+      const spy = chai.spy.on(console, 'log');
+      doWhileLoop(10);
+      expect(spy).to.have.been.called.exactly(10);
     })
   })
 })


### PR DESCRIPTION
@sgharms 
goes with https://github.com/learn-co-curriculum/javascript-intro-to-looping/pull/59

tests could've been passed before with the following (meaning without the incrementVariable() from the readme, with this being irrelevant i think some students were getting confused)

```
function doWhileLoop(arr){
  do {
    arr.pop();
  } while (arr.length);
  return arr;
}
```